### PR TITLE
feat(login): implement role-based login screen and redirection

### DIFF
--- a/src/app/public/pages/login/login.component.css
+++ b/src/app/public/pages/login/login.component.css
@@ -1,0 +1,21 @@
+:host {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+  background-color: #ffffff;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 400px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  text-align: center;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.15);
+  border-radius: 16px;
+  background-color: #fdfdfd;
+}

--- a/src/app/public/pages/login/login.component.html
+++ b/src/app/public/pages/login/login.component.html
@@ -1,0 +1,22 @@
+<mat-card class="login-card">
+  <h2>Bienvenido a PlatoX</h2>
+
+  <mat-radio-group [(ngModel)]="role" class="role-selector">
+    <mat-radio-button value="diner">Comensal</mat-radio-button>
+    <mat-radio-button value="chef">Chef / Restaurante</mat-radio-button>
+  </mat-radio-group>
+
+  <mat-form-field appearance="fill">
+    <mat-label>Correo electrónico</mat-label>
+    <input matInput [(ngModel)]="email" type="email" />
+  </mat-form-field>
+
+  <mat-form-field appearance="fill">
+    <mat-label>Contraseña</mat-label>
+    <input matInput [(ngModel)]="password" type="password" />
+  </mat-form-field>
+
+  <button mat-raised-button color="primary" (click)="login()">
+    Iniciar sesión
+  </button>
+</mat-card>

--- a/src/app/public/pages/login/login.component.spec.ts
+++ b/src/app/public/pages/login/login.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/public/pages/login/login.component.ts
+++ b/src/app/public/pages/login/login.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatRadioModule } from '@angular/material/radio';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css'],
+  imports: [
+    FormsModule,
+    MatCardModule,
+    MatInputModule,
+    MatButtonModule,
+    MatRadioModule,
+  ]
+})
+export class LoginComponent {
+  email = '';
+  password = '';
+  role: 'diner' | 'chef' = 'diner';
+
+  constructor(private router: Router) {}
+
+  login() {
+    if (!this.email || !this.password) {
+      alert('Por favor, complete todos los campos.');
+      return;
+    }
+
+    // Guardar role simulado
+    localStorage.setItem('userRole', this.role);
+
+    // Redirigir según el rol
+    this.router.navigate([`/${this.role}/home`]);
+  }
+}


### PR DESCRIPTION
- Added login UI with radio buttons to select role (Diner/ Chef)
- On submit, saves userRole in localStorage
- Redirects to /diner/home or /chef/home accordingly
- Applied centered layout and modern styling for login card