### PR TITLE
feat(favorites): implement favorite system with standalone bounded context

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -14,6 +14,7 @@ import {
 import {
   ExploreRestaurantDetailsComponent
 } from './explore/components/explore-restaurant-details/explore-restaurant-details.component';
+import {FavoriteListComponent} from './favorites/components/favorite-list/favorite-list.component';
 
 const PageNotFoundComponent = () =>
   import('./public/pages/page-not-found/page-not-found.component')
@@ -27,10 +28,10 @@ export const routes: Routes = [
     children: [
       {path: 'home', component: HomeComponent},
       {path: 'map', component: MapComponent},
-      //{ path: 'favorites', component: FavoritesComponent },*/
+      {path: 'favorites', component: FavoriteListComponent },
       {path: 'profile', component: ProfilePageComponent},
-      { path: 'restaurants', component: ExploreRestaurantListComponent },
-      { path: 'restaurants/:id', component: ExploreRestaurantDetailsComponent }
+      {path: 'restaurants', component: ExploreRestaurantListComponent },
+      {path: 'restaurants/:id', component: ExploreRestaurantDetailsComponent }
     ]
   },
   {

--- a/src/app/explore/components/explore-restaurant-list/explore-restaurant-list.component.html
+++ b/src/app/explore/components/explore-restaurant-list/explore-restaurant-list.component.html
@@ -9,6 +9,14 @@
     </mat-card-content>
     <mat-card-actions>
       <a [routerLink]="['/diner/restaurants', r.id]" mat-button color="primary">Ver platos</a>
+      <button mat-button (click)="toggleFavorite(r)">
+        <mat-icon>{{ isFavorite(r.id) ? 'favorite' : 'favorite_border' }}</mat-icon>
+        {{ isFavorite(r.id) ? 'Quitar' : 'Favorito' }}
+      </button>
     </mat-card-actions>
+    <mat-chip color="accent" *ngIf="isPremiumRestaurant(r)">
+      ⭐ Chef Premium
+    </mat-chip>
+
   </mat-card>
 </div>

--- a/src/app/favorites/components/favorite-list/favorite-list.component.css
+++ b/src/app/favorites/components/favorite-list/favorite-list.component.css
@@ -1,0 +1,18 @@
+.container {
+  padding: 2rem;
+}
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+mat-card {
+  width: 300px;
+}
+
+.empty-card {
+  margin-top: 2rem;
+  text-align: center;
+}

--- a/src/app/favorites/components/favorite-list/favorite-list.component.html
+++ b/src/app/favorites/components/favorite-list/favorite-list.component.html
@@ -1,0 +1,33 @@
+<div class="container">
+  <h2 class="mat-headline-5">Mis Restaurantes Favoritos</h2>
+
+  <ng-container *ngIf="favorites.length > 0; else noFavorites">
+    <div class="grid">
+      <mat-card *ngFor="let r of favorites" class="mat-elevation-z2">
+        <mat-card-header>
+          <mat-card-title>{{ r.name }}</mat-card-title>
+          <mat-card-subtitle>{{ r.foodType }}</mat-card-subtitle>
+        </mat-card-header>
+
+        <mat-card-content>
+          <p>{{ r.description }}</p>
+          <p><strong>Dirección:</strong> {{ r.address }}</p>
+        </mat-card-content>
+
+        <mat-card-actions>
+          <button mat-button color="accent" [routerLink]="['/diner/restaurants', r.id]">
+            Ver detalles <mat-icon>arrow_forward</mat-icon>
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    </div>
+  </ng-container>
+
+  <ng-template #noFavorites>
+    <mat-card class="mat-elevation-z3 empty-card">
+      <mat-card-content>
+        <p>No tienes restaurantes marcados como favoritos aún.</p>
+      </mat-card-content>
+    </mat-card>
+  </ng-template>
+</div>

--- a/src/app/favorites/components/favorite-list/favorite-list.component.spec.ts
+++ b/src/app/favorites/components/favorite-list/favorite-list.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FavoriteListComponent } from './favorite-list.component';
+
+describe('FavoriteListComponent', () => {
+  let component: FavoriteListComponent;
+  let fixture: ComponentFixture<FavoriteListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FavoriteListComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FavoriteListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/favorites/components/favorite-list/favorite-list.component.ts
+++ b/src/app/favorites/components/favorite-list/favorite-list.component.ts
@@ -1,0 +1,44 @@
+import {Component, OnInit} from '@angular/core';
+import {Restaurant} from '../../../restaurant/model/restaurant.entity';
+import {FavoriteService} from '../../services/favorite.service';
+import {RestaurantService} from '../../../restaurant/services/restaurant.service';
+import {UserService} from '../../../profile/services/user.service';
+import {MatCardModule} from '@angular/material/card';
+import {RouterLink} from '@angular/router';
+import {MatButton} from '@angular/material/button';
+import {NgForOf, NgIf} from '@angular/common';
+import {MatIcon} from '@angular/material/icon';
+
+@Component({
+  selector: 'app-favorite-list',
+  imports: [
+    MatCardModule,
+    RouterLink,
+    MatButton,
+    MatIcon,
+    NgIf,
+    NgForOf
+  ],
+  templateUrl: './favorite-list.component.html',
+  styleUrl: './favorite-list.component.css'
+})
+export class FavoriteListComponent implements OnInit {
+  favorites: Restaurant[] = [];
+
+  constructor(
+    private favoriteService: FavoriteService,
+    private restaurantService: RestaurantService,
+    private userService: UserService
+  ) {}
+
+  ngOnInit(): void {
+    const userId = this.userService.getUserId();
+
+    this.favoriteService.getByUser(userId).subscribe(favs => {
+      const ids = favs.map(f => f.restaurantId);
+      this.restaurantService.getAll().subscribe(all => {
+        this.favorites = all.filter(r => ids.includes(r.id));
+      });
+    });
+  }
+}

--- a/src/app/favorites/model/favorite.entity.spec.ts
+++ b/src/app/favorites/model/favorite.entity.spec.ts
@@ -1,0 +1,7 @@
+import { Favorite } from './favorite.entity';
+
+describe('Favorite', () => {
+  it('should create an instance', () => {
+    expect(new Favorite()).toBeTruthy();
+  });
+});

--- a/src/app/favorites/model/favorite.entity.ts
+++ b/src/app/favorites/model/favorite.entity.ts
@@ -1,0 +1,11 @@
+export class Favorite {
+  id: number;
+  userId: number;
+  restaurantId: number;
+
+  constructor(favorite:{id?: number, userId?: number, restaurantId?: number}) {
+    this.id = favorite.id || 0;
+    this.userId = favorite.userId || 0;
+    this.restaurantId = favorite.restaurantId || 0;
+  }
+}

--- a/src/app/favorites/services/favorite.service.spec.ts
+++ b/src/app/favorites/services/favorite.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FavoriteService } from './favorite.service';
+
+describe('FavoriteService', () => {
+  let service: FavoriteService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FavoriteService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/favorites/services/favorite.service.ts
+++ b/src/app/favorites/services/favorite.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class FavoriteService {
+  private baseUrl = `${environment.serverBaseUrl}/favorites`;
+
+  constructor(private http: HttpClient) {}
+
+  getByUser(userId: number): Observable<any[]> {
+    return this.http.get<any[]>(`${this.baseUrl}?userId=${userId}`);
+  }
+
+  add(userId: number, restaurantId: number): Observable<any> {
+    return this.http.post(this.baseUrl, { userId, restaurantId });
+  }
+
+  remove(favId: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${favId}`);
+  }
+}


### PR DESCRIPTION
- Created favorite.entity and favorite.service for managing user favorites in db.json
- Added explore-restaurant-list integration with favorite toggle button
- Displayed favorite state with Material icons (favorite/favorite_border)
- Created FavoriteListComponent to list all favorite restaurants per user
- Structured favorites module under its own bounded context (model, services, components)
- Fully integrated with user session and role-based logic